### PR TITLE
Updated composer.json to allow forwards compatiblity with Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 
     "require": {
         "jms/metadata": "1.*",
-        "symfony/property-access": "2.2.*@RC"
+        "symfony/property-access": "~2.2"
     },
 
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,25 +1,36 @@
 {
-    "hash": "f80290fca15abb9e25deadfb209d33d1",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "ffa9aed9c33265129f4f73a71e23d198",
     "packages": [
         {
             "name": "jms/metadata",
-            "version": "1.1.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/schmittjoh/metadata",
-                "reference": "1.1.1"
+                "url": "https://github.com/schmittjoh/metadata.git",
+                "reference": "1.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/schmittjoh/metadata/zipball/1.1.1",
-                "reference": "1.1.1",
+                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/1.3.0",
+                "reference": "1.3.0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
-            "time": "2012-01-02 13:32:49",
+            "require-dev": {
+                "doctrine/common": ">=2.0,<2.4-dev"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Metadata\\": "src/"
@@ -43,27 +54,27 @@
                 "metadata",
                 "xml",
                 "yaml"
-            ]
+            ],
+            "time": "2013-01-22 12:51:18"
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.2.0-RC2",
+            "version": "v2.2.1",
             "target-dir": "Symfony/Component/PropertyAccess",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/PropertyAccess",
-                "reference": "v2.2.0-RC1"
+                "url": "https://github.com/symfony/PropertyAccess.git",
+                "reference": "v2.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/v2.2.0-RC1",
-                "reference": "v2.2.0-RC1",
+                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/v2.2.1",
+                "reference": "v2.2.1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
-            "time": "2013-02-04 20:27:45",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -101,7 +112,8 @@
                 "property",
                 "property path",
                 "reflection"
-            ]
+            ],
+            "time": "2013-03-28 15:37:15"
         }
     ],
     "packages-dev": [
@@ -122,7 +134,6 @@
             "require": {
                 "php": ">=5.3.2"
             },
-            "time": "2012-09-19 22:55:18",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -172,38 +183,38 @@
                 "eventmanager",
                 "persistence",
                 "spl"
-            ]
+            ],
+            "time": "2012-09-19 22:55:18"
         },
         {
             "name": "symfony/routing",
-            "version": "v2.1.7",
+            "version": "v2.1.10",
             "target-dir": "Symfony/Component/Routing",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Routing",
-                "reference": "v2.1.7"
+                "url": "https://github.com/symfony/Routing.git",
+                "reference": "v2.1.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Routing/zipball/v2.1.7",
-                "reference": "v2.1.7",
+                "url": "https://api.github.com/repos/symfony/Routing/zipball/v2.1.10",
+                "reference": "v2.1.10",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "doctrine/common": ">=2.2,<2.4-dev",
+                "doctrine/common": ">=2.2,<3.0",
                 "symfony/config": "2.1.*",
                 "symfony/http-kernel": "2.1.*",
                 "symfony/yaml": "2.1.*"
             },
             "suggest": {
-                "doctrine/common": ">=2.2,<2.4-dev",
+                "doctrine/common": "~2.2",
                 "symfony/config": "2.1.*",
                 "symfony/yaml": "2.1.*"
             },
-            "time": "2013-01-09 08:51:07",
             "type": "library",
             "autoload": {
                 "psr-0": {
@@ -225,14 +236,21 @@
                 }
             ],
             "description": "Symfony Routing Component",
-            "homepage": "http://symfony.com"
+            "homepage": "http://symfony.com",
+            "time": "2013-05-06 10:48:41"
         }
     ],
     "aliases": [
 
     ],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "symfony/property-access": 5
-    }
+    "stability-flags": [
+
+    ],
+    "platform": [
+
+    ],
+    "platform-dev": [
+
+    ]
 }


### PR DESCRIPTION
Currently it's not possible to use object-routing in symfony 2.3 projects due to dependency restrictions for the `symfony/property-access` package.

This PR updates the `symfony/property-access` version to ~2.2 which will allow for future versions up to 2.3 to be loaded.

The `composer.lock` file has also been updated to reflect the new changes. The unit tests have been run against both property access v2.2.1 and v2.3.0-RC1 and all passed.
