### PR TITLE
Symfony3 Support

### DIFF
--- a/src/JMS/ObjectRouting/Metadata/ClassMetadata.php
+++ b/src/JMS/ObjectRouting/Metadata/ClassMetadata.php
@@ -20,14 +20,24 @@ namespace JMS\ObjectRouting\Metadata;
 
 use Metadata\MergeableClassMetadata;
 
+/**
+ * Class ClassMetadata
+ *
+ * @package JMS\ObjectRouting\Metadata
+ */
 class ClassMetadata extends MergeableClassMetadata
 {
     public $routes = array();
 
+    /**
+     * @param string $type
+     * @param string $name
+     * @param array  $params
+     */
     public function addRoute($type, $name, array $params = array())
     {
         $this->routes[$type] = array(
-            'name' => $name,
+            'name'   => $name,
             'params' => $params,
         );
     }

--- a/src/JMS/ObjectRouting/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/ObjectRouting/Metadata/Driver/AnnotationDriver.php
@@ -23,15 +23,31 @@ use JMS\ObjectRouting\Annotation\ObjectRoute;
 use JMS\ObjectRouting\Metadata\ClassMetadata;
 use Metadata\Driver\DriverInterface;
 
+/**
+ * Class AnnotationDriver
+ *
+ * @package JMS\ObjectRouting\Metadata\Driver
+ */
 class AnnotationDriver implements DriverInterface
 {
+    /**
+     * @var Reader
+     */
     private $reader;
 
+    /**
+     * @param Reader $reader
+     */
     public function __construct(Reader $reader)
     {
         $this->reader = $reader;
     }
 
+    /**
+     * @param \ReflectionClass $class
+     *
+     * @return ClassMetadata|null
+     */
     public function loadMetadataForClass(\ReflectionClass $class)
     {
         $metadata = new ClassMetadata($class->name);

--- a/src/JMS/ObjectRouting/ObjectRouter.php
+++ b/src/JMS/ObjectRouting/ObjectRouter.php
@@ -24,13 +24,33 @@ use JMS\ObjectRouting\Metadata\Driver\AnnotationDriver;
 use Metadata\MetadataFactory;
 use Metadata\MetadataFactoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * Class ObjectRouter
+ *
+ * @package JMS\ObjectRouting
+ */
 class ObjectRouter
 {
+    /**
+     * @var RouterInterface
+     */
     private $router;
+    /**
+     * @var MetadataFactoryInterface
+     */
     private $metadataFactory;
+    /**
+     * @var PropertyAccessor
+     */
     private $accessor;
 
+    /**
+     * @param RouterInterface $router
+     *
+     * @return ObjectRouter
+     */
     public static function create(RouterInterface $router)
     {
         return new self(
@@ -41,6 +61,10 @@ class ObjectRouter
         );
     }
 
+    /**
+     * @param RouterInterface          $router
+     * @param MetadataFactoryInterface $metadataFactory
+     */
     public function __construct(RouterInterface $router, MetadataFactoryInterface $metadataFactory)
     {
         $this->router = $router;
@@ -51,16 +75,16 @@ class ObjectRouter
     /**
      * Generates a path for an object.
      *
-     * @param string $type
-     * @param object $object
+     * @param string  $type
+     * @param object  $object
      * @param boolean $absolute
-     * @param array $extraParams
+     * @param array   $extraParams
      *
      * @throws \InvalidArgumentException
      */
-    public function generate($type, $object, $absolute = false, array $extraParams = array())
+    public function generate($type, $object, $absolute = UrlGeneratorInterface::ABSOLUTE_URL, array $extraParams = array())
     {
-        if ( ! is_object($object)) {
+        if (!is_object($object)) {
             throw new \InvalidArgumentException(sprintf('$object must be an object, but got "%s".', gettype($object)));
         }
 
@@ -70,13 +94,13 @@ class ObjectRouter
             throw new \RuntimeException(sprintf('There were no object routes defined for class "%s".', get_class($object)));
         }
 
-        if ( ! isset($metadata->routes[$type])) {
+        if (!isset($metadata->routes[$type])) {
             throw new \RuntimeException(sprintf(
-                'The object of class "%s" has no route with type "%s". Available types: %s',
-                get_class($object),
-                $type,
-                implode(', ', array_keys($metadata->routes))
-            ));
+                                            'The object of class "%s" has no route with type "%s". Available types: %s',
+                                            get_class($object),
+                                            $type,
+                                            implode(', ', array_keys($metadata->routes))
+                                        ));
         }
 
         $route = $metadata->routes[$type];
@@ -89,13 +113,27 @@ class ObjectRouter
         return $this->router->generate($route['name'], $params, $absolute);
     }
 
+    /**
+     * @param string $type
+     * @param object $object
+     * @param array  $extraParams
+     *
+     * @return mixed
+     */
     public function path($type, $object, array $extraParams = array())
     {
-        return $this->generate($type, $object, false, $extraParams);
+        return $this->generate($type, $object, UrlGeneratorInterface::ABSOLUTE_URL, $extraParams);
     }
 
+    /**
+     * @param string $type
+     * @param object $object
+     * @param array  $extraParams
+     *
+     * @return mixed
+     */
     public function url($type, $object, array $extraParams = array())
     {
-        return $this->generate($type, $object, true, $extraParams);
+        return $this->generate($type, $object, UrlGeneratorInterface::ABSOLUTE_URL, $extraParams);
     }
 }

--- a/src/JMS/ObjectRouting/RouterInterface.php
+++ b/src/JMS/ObjectRouting/RouterInterface.php
@@ -18,7 +18,21 @@
 
 namespace JMS\ObjectRouting;
 
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Interface RouterInterface
+ *
+ * @package JMS\ObjectRouting
+ */
 interface RouterInterface
 {
-    public function generate($name, array $params, $absolute = false);
+    /**
+     * @param string     $name
+     * @param array      $params
+     * @param bool|false $absolute
+     *
+     * @return mixed
+     */
+    public function generate($name, array $params, $absolute = UrlGeneratorInterface::ABSOLUTE_URL);
 }

--- a/src/JMS/ObjectRouting/Symfony/Symfony21Adapter.php
+++ b/src/JMS/ObjectRouting/Symfony/Symfony21Adapter.php
@@ -19,17 +19,36 @@
 namespace JMS\ObjectRouting\Symfony;
 
 use JMS\ObjectRouting\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * Class Symfony21Adapter
+ *
+ * @package JMS\ObjectRouting\Symfony
+ */
 class Symfony21Adapter implements RouterInterface
 {
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
     private $delegate;
 
+    /**
+     * @param \Symfony\Component\Routing\RouterInterface $router
+     */
     public function __construct(\Symfony\Component\Routing\RouterInterface $router)
     {
         $this->delegate = $router;
     }
 
-    public function generate($name, array $params, $absolute = false)
+    /**
+     * @param string         $name
+     * @param array          $params
+     * @param bool|false|int $absolute
+     *
+     * @return string
+     */
+    public function generate($name, array $params, $absolute = UrlGeneratorInterface::ABSOLUTE_URL)
     {
         return $this->delegate->generate($name, $params, $absolute);
     }

--- a/src/JMS/ObjectRouting/Twig/RoutingExtension.php
+++ b/src/JMS/ObjectRouting/Twig/RoutingExtension.php
@@ -3,34 +3,72 @@
 namespace JMS\ObjectRouting\Twig;
 
 use JMS\ObjectRouting\ObjectRouter;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * Class RoutingExtension
+ *
+ * @package JMS\ObjectRouting\Twig
+ */
 class RoutingExtension extends \Twig_Extension
 {
+    /**
+     * @var ObjectRouter
+     */
     private $router;
 
+    /**
+     * @param ObjectRouter $router
+     */
     public function __construct(ObjectRouter $router)
     {
         $this->router = $router;
     }
 
+    /**
+     * @return array
+     */
     public function getFunctions()
     {
-        return array(
-            'object_path' => new \Twig_Function_Method($this, 'path'),
-            'object_url'  => new \Twig_Function_Method($this, 'url'),
-        );
+        return [
+            new \Twig_SimpleFunction('object_path', [
+                $this,
+                'path'
+            ]),
+            new \Twig_SimpleFunction('object_url', [
+                $this,
+                'url'
+            ])
+        ];
     }
 
+    /**
+     * @param string $type
+     * @param object $object
+     * @param array  $extraParams
+     *
+     * @return mixed
+     */
     public function url($type, $object, array $extraParams = array())
     {
-        return $this->router->generate($type, $object, true, $extraParams);
+        return $this->router->generate($type, $object, UrlGeneratorInterface::ABSOLUTE_URL, $extraParams);
     }
 
+    /**
+     * @param string $type
+     * @param object $object
+     * @param array  $extraParams
+     *
+     * @return mixed
+     */
     public function path($type, $object, array $extraParams = array())
     {
-        return $this->router->generate($type, $object, false, $extraParams);
+        return $this->router->generate($type, $object, UrlGeneratorInterface::ABSOLUTE_PATH, $extraParams);
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return 'jms.object_routing';


### PR DESCRIPTION
Commit says Symfony2, just a Typo. 

Fixes:

- "Using an instance of "Twig_Function_Method" for function "object_path" is deprecated since version 1.21. Use Twig_SimpleFunction instead."

- "The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead. "