### PR TITLE
Make ClassMetadata serializable

### DIFF
--- a/src/JMS/ObjectRouting/Metadata/ClassMetadata.php
+++ b/src/JMS/ObjectRouting/Metadata/ClassMetadata.php
@@ -31,4 +31,25 @@ class ClassMetadata extends MergeableClassMetadata
             'params' => $params,
         );
     }
+
+    public function serialize()
+    {
+        return serialize(
+            array(
+                $this->routes,
+                parent::serialize(),
+            )
+        );
+    }
+
+    public function unserialize($str)
+    {
+        list(
+            $this->routes,
+            $parentStr
+            ) = unserialize($str);
+
+        parent::unserialize($parentStr);
+    }
+
 }


### PR DESCRIPTION
In order to cache the metadata of a class with the php build-in serialize function, we need to add the "routes" property of the ClassMetadata Class. This pull request fixes this behaviour.