### PR TITLE
Push the lowest dependencies up.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "license": "Apache2",
 
     "require": {
-        "jms/metadata": "1.*",
+        "jms/metadata": "~1.3",
         "symfony/property-access": "~2.2 || ~3.0"
     },
 
     "require-dev": {
         "symfony/routing": "~2.1||~3.0",
-        "doctrine/common": "2.*",
+        "doctrine/common": "~2.2",
         "symfony/yaml": "~2.0 || ~3.0"
     },
 

--- a/tests/JMS/Tests/ObjectRouting/Symfony/Symfony22AdapterTest.php
+++ b/tests/JMS/Tests/ObjectRouting/Symfony/Symfony22AdapterTest.php
@@ -13,6 +13,9 @@ class Symfony22AdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerate()
     {
+        if(!defined('Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL')){
+            $this->markTestSkipped('Skipping this test because required constant UrlGeneratorInterface::ABSOLUTE_URL is not defined.');
+        }
         $this->router->expects($this->once())
             ->method('generate')
             ->with('foo', array('bar' => 'baz'), UrlGeneratorInterface::ABSOLUTE_URL)


### PR DESCRIPTION
This pull request contains minimal changes to successfully run the tests after a "composer update --prefer-lowest". But before and possible after merging this request there should be a release of this library imo. @schmittjoh What do you think?